### PR TITLE
Accept a newer version of npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "main" : "epsg.js",
   "engines" : {
     "node" : ">=0.6.x",
-    "npm" : "1.1.x"
+    "npm" : ">=1.1.x"
   },
   "keywords" : ["geo", "proj4", "proj4js", "projections", "mapping"],
   "dependencies" : {


### PR DESCRIPTION
The current `package.json` has a limitation for the `npm` version so we encounter the warning on the latest Node.js and npm.

This change just eases the version limitation of npm to suppress the warning.